### PR TITLE
Fixed trailing commas bug with the config scraper

### DIFF
--- a/scripts/extractConfig.peg
+++ b/scripts/extractConfig.peg
@@ -8,8 +8,7 @@ Registration
 
 Struct
   = _ "{" items:(Item "," _)* last:(Item)? _ "}" _ {
-  		if (last !== null) return Object.fromEntries(items.map(v => v[0]).concat([last]));
-      else return Object.fromEntries(items.map(v => v[0]));
+      return Object.fromEntries(items.map(v => v[0]).concat((last !== null) ? [last] : []));
     }
 
 Item


### PR DESCRIPTION
Previously configs such as `["hello world",]` would cause the scraper to incorrectly parse the contents. This pull fixes that.